### PR TITLE
Advisory locks

### DIFF
--- a/lib/apartment/active_record/migrator.rb
+++ b/lib/apartment/active_record/migrator.rb
@@ -1,0 +1,12 @@
+module ActiveRecord
+  class Migrator < ActiveRecord # :nodoc:
+    class << self
+      def generate_migrator_advisory_lock_id
+        hash_input = ActiveRecord::Base.connection.current_database
+        hash_input += ActiveRecord::Base.connection.current_schema if ActiveRecord::Base.connection.respond_to?(:current_schema)
+        db_name_hash = Zlib.crc32(hash_input)
+        MIGRATOR_SALT * db_name_hash
+      end
+    end
+  end
+end

--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -42,11 +42,22 @@ module Apartment
       create_tenant(tenant_name) if strategy == :create_tenant
 
       puts("Migrating #{tenant_name} tenant")
-      Apartment::Migrator.migrate tenant_name
+      Apartment::Migrator.migrate(tenant_name)
     rescue Apartment::TenantNotFound => e
       raise e if strategy == :raise_exception
 
       puts e.message
     end
+
+    def self.run_with_advisory_lock
+      db_name_hash = Zlib.crc32(ActiveRecord::Base.connection.current_database) * 2_053_462_845
+      obtained_lock = ActiveRecord::Base.connection.select_value("select pg_try_advisory_lock(#{db_name_hash});")
+      begin
+        yield
+      ensure
+        ActiveRecord::Base.connection.execute("select pg_advisory_unlock(#{db_name_hash});")
+      end
+    end
+
   end
 end

--- a/lib/apartment/tasks/task_helper.rb
+++ b/lib/apartment/tasks/task_helper.rb
@@ -3,8 +3,10 @@
 module Apartment
   module TaskHelper
     def self.each_tenant(&block)
-      Parallel.each(tenants_without_default, in_threads: Apartment.parallel_migration_threads) do |tenant|
-        block.call(tenant)
+      run_with_advisory_lock do
+        Parallel.each(tenants_without_default, in_threads: Apartment.parallel_migration_threads) do |tenant|
+          block.call(tenant)
+        end
       end
     end
 


### PR DESCRIPTION
- Enable Parallel migrations on rails 6.1 by monkeypatching active record
- Changes to create and run migrations in one advisory_lock - Disable advisory_locks in database.yml